### PR TITLE
Do not delete null pointer in Allocator destructor

### DIFF
--- a/Allocator/Allocator.h
+++ b/Allocator/Allocator.h
@@ -39,7 +39,8 @@ class Allocator : private MemoryPool<T, growSize>
 
         ~Allocator()
         {
-            delete defaultAllocator;
+            if (defaultAllocator)
+                delete defaultAllocator;
         }
 
         pointer allocate(size_type n, std::allocator<void>::const_pointer hint = 0)


### PR DESCRIPTION
Since defaultAllocator is not allocated in all scenarios, a null check may be introduced in the Allocator's destructor