### PR TITLE
Fix uninitialized field

### DIFF
--- a/Allocator.h
+++ b/Allocator.h
@@ -83,7 +83,7 @@ template <class T, std::size_t growSize = 1024>
 class Allocator : private MemoryPool<T, growSize>
 {
 #ifdef _WIN32
-    Allocator *copyAllocator;
+    Allocator *copyAllocator = nullptr;
     std::allocator<T> *rebindAllocator = nullptr;
 #endif
 


### PR DESCRIPTION
This fixes an issue introduced with the last MSVC workaround changes where the `copyAllocator` field remains uninitialized, leading to an access violation in `Allocator::allocate`.